### PR TITLE
chore: internalize buffer classes from pg-protocol

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "pg-gateway-next",
+  "name": "pg-gateway",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "pg-gateway",
+  "name": "pg-gateway-next",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
@@ -1758,7 +1758,8 @@
     "node_modules/pg-protocol": {
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.6.1.tgz",
-      "integrity": "sha512-jPIlvgoD63hrEuihvIg+tJhoGjUsLPn6poJY9N5CnlPd91c2T18T/9zBtLxZSb1EhYxBRoZJtzScCaWlYLtktg=="
+      "integrity": "sha512-jPIlvgoD63hrEuihvIg+tJhoGjUsLPn6poJY9N5CnlPd91c2T18T/9zBtLxZSb1EhYxBRoZJtzScCaWlYLtktg==",
+      "dev": true
     },
     "node_modules/pg-types": {
       "version": "2.2.0",
@@ -2904,15 +2905,13 @@
     "packages/pg-gateway": {
       "version": "0.3.0-alpha.1",
       "license": "MIT",
-      "dependencies": {
-        "pg-protocol": "^1.6.1"
-      },
       "devDependencies": {
         "@biomejs/biome": "1.8.3",
         "@electric-sql/pglite": "0.2.0-alpha.7",
         "@total-typescript/tsconfig": "^1.0.4",
         "@types/node": "^20.14.11",
         "pg": "^8.12.0",
+        "pg-protocol": "^1.6.1",
         "tsup": "^8.2.3",
         "tsx": "^4.16.2",
         "typescript": "^5.5.3"

--- a/packages/pg-gateway/package.json
+++ b/packages/pg-gateway/package.json
@@ -26,15 +26,13 @@
     "lint": "biome lint --error-on-warnings .",
     "type-check": "tsc --noEmit"
   },
-  "dependencies": {
-    "pg-protocol": "^1.6.1"
-  },
   "devDependencies": {
     "@biomejs/biome": "1.8.3",
     "@electric-sql/pglite": "0.2.0-alpha.7",
     "@total-typescript/tsconfig": "^1.0.4",
     "@types/node": "^20.14.11",
     "pg": "^8.12.0",
+    "pg-protocol": "^1.6.1",
     "tsup": "^8.2.3",
     "tsx": "^4.16.2",
     "typescript": "^5.5.3"

--- a/packages/pg-gateway/src/auth/base-auth-flow.ts
+++ b/packages/pg-gateway/src/auth/base-auth-flow.ts
@@ -1,10 +1,10 @@
 import type { Socket } from 'node:net';
-import type { BufferReader } from 'pg-protocol/dist/buffer-reader.js';
-import type { Writer } from 'pg-protocol/dist/buffer-writer.js';
 import {
   type BackendError,
   createBackendErrorMessage,
 } from '../backend-error.js';
+import type { BufferReader } from '../buffer-reader.js';
+import type { BufferWriter } from '../buffer-writer.js';
 import type { ConnectionState } from '../connection.types.js';
 
 export interface AuthFlow {
@@ -16,13 +16,13 @@ export interface AuthFlow {
 export abstract class BaseAuthFlow implements AuthFlow {
   protected socket: Socket;
   protected reader: BufferReader;
-  protected writer: Writer;
+  protected writer: BufferWriter;
   protected connectionState: ConnectionState;
 
   constructor(params: {
     socket: Socket;
     reader: BufferReader;
-    writer: Writer;
+    writer: BufferWriter;
     connectionState: ConnectionState;
   }) {
     this.socket = params.socket;

--- a/packages/pg-gateway/src/auth/cert.ts
+++ b/packages/pg-gateway/src/auth/cert.ts
@@ -1,7 +1,7 @@
 import type { Socket } from 'node:net';
 import { type PeerCertificate, TLSSocket } from 'node:tls';
-import type { BufferReader } from 'pg-protocol/dist/buffer-reader.js';
-import type { Writer } from 'pg-protocol/dist/buffer-writer.js';
+import type { BufferReader } from '../buffer-reader.js';
+import type { BufferWriter } from '../buffer-writer.js';
 import type { ConnectionState } from '../connection.types';
 import { BaseAuthFlow } from './base-auth-flow';
 
@@ -28,7 +28,7 @@ export class CertAuthFlow extends BaseAuthFlow {
     username: string;
     socket: Socket;
     reader: BufferReader;
-    writer: Writer;
+    writer: BufferWriter;
     connectionState: ConnectionState;
   }) {
     super(params);

--- a/packages/pg-gateway/src/auth/index.ts
+++ b/packages/pg-gateway/src/auth/index.ts
@@ -1,6 +1,6 @@
 import type { Socket } from 'node:net';
-import type { BufferReader } from 'pg-protocol/dist/buffer-reader.js';
-import type { Writer } from 'pg-protocol/dist/buffer-writer.js';
+import type { BufferReader } from '../buffer-reader.js';
+import type { BufferWriter } from '../buffer-writer.js';
 import type { ConnectionState } from '../connection.types';
 import type { AuthFlow } from './base-auth-flow';
 import { CertAuthFlow, type CertAuthOptions } from './cert';
@@ -22,7 +22,7 @@ export type AuthOptions =
 export function createAuthFlow(options: {
   socket: Socket;
   reader: BufferReader;
-  writer: Writer;
+  writer: BufferWriter;
   auth: AuthOptions;
   username: string;
   connectionState: ConnectionState;

--- a/packages/pg-gateway/src/auth/md5.ts
+++ b/packages/pg-gateway/src/auth/md5.ts
@@ -1,7 +1,7 @@
 import { type BinaryLike, createHash } from 'node:crypto';
 import type { Socket } from 'node:net';
-import type { BufferReader } from 'pg-protocol/dist/buffer-reader.js';
-import type { Writer } from 'pg-protocol/dist/buffer-writer.js';
+import type { BufferReader } from '../buffer-reader.js';
+import type { BufferWriter } from '../buffer-writer.js';
 import type { ConnectionState } from '../connection.types';
 import { BackendMessageCode } from '../message-codes';
 import { BaseAuthFlow } from './base-auth-flow';
@@ -36,7 +36,7 @@ export class Md5AuthFlow extends BaseAuthFlow {
     username: string;
     socket: Socket;
     reader: BufferReader;
-    writer: Writer;
+    writer: BufferWriter;
     connectionState: ConnectionState;
   }) {
     super(params);

--- a/packages/pg-gateway/src/auth/password.ts
+++ b/packages/pg-gateway/src/auth/password.ts
@@ -1,6 +1,6 @@
 import type { Socket } from 'node:net';
-import type { BufferReader } from 'pg-protocol/dist/buffer-reader.js';
-import type { Writer } from 'pg-protocol/dist/buffer-writer.js';
+import type { BufferReader } from '../buffer-reader.js';
+import type { BufferWriter } from '../buffer-writer.js';
 import type { ConnectionState } from '../connection.types';
 import { BackendMessageCode } from '../message-codes';
 import { BaseAuthFlow } from './base-auth-flow';
@@ -39,7 +39,7 @@ export class PasswordAuthFlow extends BaseAuthFlow {
     username: string;
     socket: Socket;
     reader: BufferReader;
-    writer: Writer;
+    writer: BufferWriter;
     connectionState: ConnectionState;
   }) {
     super(params);

--- a/packages/pg-gateway/src/auth/sasl/sasl-mechanism.ts
+++ b/packages/pg-gateway/src/auth/sasl/sasl-mechanism.ts
@@ -1,9 +1,9 @@
 import type { Socket } from 'node:net';
-import type { Writer } from 'pg-protocol/dist/buffer-writer.js';
 import {
   type BackendError,
   createBackendErrorMessage,
 } from '../../backend-error.js';
+import type { BufferWriter } from '../../buffer-writer.js';
 import { BackendMessageCode } from '../../message-codes.js';
 
 const SaslMessageCode = {
@@ -14,10 +14,10 @@ const SaslMessageCode = {
 
 export class SaslMechanism {
   socket: Socket;
-  writer: Writer;
+  writer: BufferWriter;
   constructor(params: {
     socket: Socket;
-    writer: Writer;
+    writer: BufferWriter;
   }) {
     this.socket = params.socket;
     this.writer = params.writer;

--- a/packages/pg-gateway/src/auth/sasl/scram-sha-256.ts
+++ b/packages/pg-gateway/src/auth/sasl/scram-sha-256.ts
@@ -6,8 +6,8 @@ import {
   timingSafeEqual,
 } from 'node:crypto';
 import type { Socket } from 'node:net';
-import type { BufferReader } from 'pg-protocol/dist/buffer-reader.js';
-import type { Writer } from 'pg-protocol/dist/buffer-writer.js';
+import type { BufferReader } from '../../buffer-reader.js';
+import type { BufferWriter } from '../../buffer-writer.js';
 import type { ConnectionState } from '../../connection.types';
 import type { AuthFlow } from '../base-auth-flow';
 import { SaslMechanism } from './sasl-mechanism';
@@ -129,7 +129,7 @@ export class ScramSha256AuthFlow extends SaslMechanism implements AuthFlow {
     username: string;
     socket: Socket;
     reader: BufferReader;
-    writer: Writer;
+    writer: BufferWriter;
     connectionState: ConnectionState;
   }) {
     super({

--- a/packages/pg-gateway/src/backend-error.ts
+++ b/packages/pg-gateway/src/backend-error.ts
@@ -1,4 +1,4 @@
-import { Writer } from 'pg-protocol/dist/buffer-writer.js';
+import { BufferWriter } from './buffer-writer.js';
 import { BackendMessageCode } from './message-codes.js';
 
 export interface BackendError {
@@ -27,7 +27,7 @@ export interface BackendError {
  * @see https://www.postgresql.org/docs/current/protocol-message-formats.html#PROTOCOL-MESSAGE-FORMATS-ERRORRESPONSE
  */
 export function createBackendErrorMessage(error: BackendError) {
-  const writer = new Writer();
+  const writer = new BufferWriter();
 
   writer.addString('S');
   writer.addCString(error.severity);

--- a/packages/pg-gateway/src/buffer-reader.ts
+++ b/packages/pg-gateway/src/buffer-reader.ts
@@ -1,0 +1,63 @@
+const emptyBuffer = Buffer.allocUnsafe(0);
+
+/**
+ *
+ *
+ * @see https://github.com/brianc/node-postgres/blob/54eb0fa216aaccd727765641e7d1cf5da2bc483d/packages/pg-protocol/src/buffer-reader.ts
+ */
+export class BufferReader {
+  private buffer: Buffer = emptyBuffer;
+
+  // TODO(bmc): support non-utf8 encoding?
+  private encoding = 'utf-8' as const;
+
+  constructor(private offset = 0) {}
+
+  public setBuffer(offset: number, buffer: Buffer): void {
+    this.offset = offset;
+    this.buffer = buffer;
+  }
+
+  public int16(): number {
+    const result = this.buffer.readInt16BE(this.offset);
+    this.offset += 2;
+    return result;
+  }
+
+  public byte(): number {
+    // biome-ignore lint/style/noNonNullAssertion: <explanation>
+    const result = this.buffer[this.offset]!;
+    this.offset++;
+    return result;
+  }
+
+  public int32(): number {
+    const result = this.buffer.readInt32BE(this.offset);
+    this.offset += 4;
+    return result;
+  }
+
+  public string(length: number): string {
+    const result = this.buffer.toString(
+      this.encoding,
+      this.offset,
+      this.offset + length,
+    );
+    this.offset += length;
+    return result;
+  }
+
+  public cstring(): string {
+    const start = this.offset;
+    let end = start;
+    while (this.buffer[end++] !== 0) {}
+    this.offset = end;
+    return this.buffer.toString(this.encoding, start, end - 1);
+  }
+
+  public bytes(length: number): Buffer {
+    const result = this.buffer.slice(this.offset, this.offset + length);
+    this.offset += length;
+    return result;
+  }
+}

--- a/packages/pg-gateway/src/buffer-reader.ts
+++ b/packages/pg-gateway/src/buffer-reader.ts
@@ -1,7 +1,7 @@
 const emptyBuffer = Buffer.allocUnsafe(0);
 
 /**
- *
+ * binary data reader tuned for decoding binary specific to the postgres binary protocol
  *
  * @see https://github.com/brianc/node-postgres/blob/54eb0fa216aaccd727765641e7d1cf5da2bc483d/packages/pg-protocol/src/buffer-reader.ts
  */

--- a/packages/pg-gateway/src/buffer-writer.ts
+++ b/packages/pg-gateway/src/buffer-writer.ts
@@ -1,0 +1,88 @@
+/**
+ * binary data  BufferWriter tuned for encoding binary specific to the postgres binary protocol
+ *
+ * @see https://github.com/brianc/node-postgres/blob/54eb0fa216aaccd727765641e7d1cf5da2bc483d/packages/pg-protocol/src/buffer- BufferWriter.ts
+ */
+export class BufferWriter {
+  private buffer: Buffer;
+  private offset = 5;
+  private headerPosition = 0;
+  constructor(private size = 256) {
+    this.buffer = Buffer.allocUnsafe(size);
+  }
+
+  private ensure(size: number): void {
+    const remaining = this.buffer.length - this.offset;
+    if (remaining < size) {
+      const oldBuffer = this.buffer;
+      // exponential growth factor of around ~ 1.5
+      // https://stackoverflow.com/questions/2269063/buffer-growth-strategy
+      const newSize = oldBuffer.length + (oldBuffer.length >> 1) + size;
+      this.buffer = Buffer.allocUnsafe(newSize);
+      oldBuffer.copy(this.buffer);
+    }
+  }
+
+  public addInt32(num: number): BufferWriter {
+    this.ensure(4);
+    this.buffer[this.offset++] = (num >>> 24) & 0xff;
+    this.buffer[this.offset++] = (num >>> 16) & 0xff;
+    this.buffer[this.offset++] = (num >>> 8) & 0xff;
+    this.buffer[this.offset++] = (num >>> 0) & 0xff;
+    return this;
+  }
+
+  public addInt16(num: number): BufferWriter {
+    this.ensure(2);
+    this.buffer[this.offset++] = (num >>> 8) & 0xff;
+    this.buffer[this.offset++] = (num >>> 0) & 0xff;
+    return this;
+  }
+
+  public addCString(string: string): BufferWriter {
+    if (!string) {
+      this.ensure(1);
+    } else {
+      const len = Buffer.byteLength(string);
+      this.ensure(len + 1); // +1 for null terminator
+      this.buffer.write(string, this.offset, 'utf-8');
+      this.offset += len;
+    }
+
+    this.buffer[this.offset++] = 0; // null terminator
+    return this;
+  }
+
+  public addString(string = ''): BufferWriter {
+    const len = Buffer.byteLength(string);
+    this.ensure(len);
+    this.buffer.write(string, this.offset);
+    this.offset += len;
+    return this;
+  }
+
+  public add(otherBuffer: Buffer): BufferWriter {
+    this.ensure(otherBuffer.length);
+    otherBuffer.copy(this.buffer, this.offset);
+    this.offset += otherBuffer.length;
+    return this;
+  }
+
+  private join(code?: number): Buffer {
+    if (code) {
+      this.buffer[this.headerPosition] = code;
+      //length is everything in this packet minus the code
+      const length = this.offset - (this.headerPosition + 1);
+      this.buffer.writeInt32BE(length, this.headerPosition + 1);
+    }
+    return this.buffer.slice(code ? 0 : 5, this.offset);
+  }
+
+  public flush(code?: number): Buffer {
+    const result = this.join(code);
+    this.offset = 5;
+    this.headerPosition = 0;
+    this.buffer = Buffer.allocUnsafe(this.size);
+    return result;
+  }
+}

--- a/packages/pg-gateway/src/connection.ts
+++ b/packages/pg-gateway/src/connection.ts
@@ -1,7 +1,7 @@
 import type { Socket } from 'node:net';
 import type { TLSSocket } from 'node:tls';
-import { BufferReader } from 'pg-protocol/dist/buffer-reader.js';
-import { Writer } from 'pg-protocol/dist/buffer-writer.js';
+import { BufferReader } from './buffer-reader.js';
+import { BufferWriter } from './buffer-writer.js';
 
 import type { AuthFlow } from './auth/base-auth-flow.js';
 import { type AuthOptions, createAuthFlow } from './auth/index.js';
@@ -133,7 +133,7 @@ export default class PostgresConnection {
   secureSocket?: TLSSocket;
   hasStarted = false;
   isAuthenticated = false;
-  writer = new Writer();
+  writer = new BufferWriter();
   reader = new BufferReader();
   clientInfo?: ClientInfo;
   tlsInfo?: TlsInfo;

--- a/packages/pg-gateway/src/types.d.ts
+++ b/packages/pg-gateway/src/types.d.ts
@@ -1,7 +1,0 @@
-declare module 'pg-protocol/dist/buffer-reader.js' {
-  export { BufferReader } from 'pg-protocol/dist/buffer-reader.d.ts';
-}
-
-declare module 'pg-protocol/dist/buffer-writer.js' {
-  export { Writer } from 'pg-protocol/dist/buffer-writer.d.ts';
-}


### PR DESCRIPTION
We had build errors because we were using internal and non exported classes from `pg-protocol`, let's see if this fix it.