### PR TITLE
chore: bump pglite

### DIFF
--- a/examples/pglite-auth/package.json
+++ b/examples/pglite-auth/package.json
@@ -11,7 +11,7 @@
   },
   "devDependencies": {
     "@biomejs/biome": "1.8.3",
-    "@electric-sql/pglite": "0.2.0-alpha.7",
+    "@electric-sql/pglite": "0.2.0-alpha.8",
     "@total-typescript/tsconfig": "^1.0.4",
     "@types/node": "^20.14.11",
     "tsx": "^4.16.2",

--- a/examples/pglite-auth/package.json
+++ b/examples/pglite-auth/package.json
@@ -7,11 +7,11 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
+    "@electric-sql/pglite": "0.2.0-alpha.8",
     "pg-gateway": "*"
   },
   "devDependencies": {
     "@biomejs/biome": "1.8.3",
-    "@electric-sql/pglite": "0.2.0-alpha.8",
     "@total-typescript/tsconfig": "^1.0.4",
     "@types/node": "^20.14.11",
     "tsx": "^4.16.2",

--- a/examples/pglite-multiple/package.json
+++ b/examples/pglite-multiple/package.json
@@ -12,7 +12,7 @@
   },
   "devDependencies": {
     "@biomejs/biome": "1.8.3",
-    "@electric-sql/pglite": "0.2.0-alpha.7",
+    "@electric-sql/pglite": "0.2.0-alpha.8",
     "@total-typescript/tsconfig": "^1.0.4",
     "@types/node": "^20.14.11",
     "tsx": "^4.16.2",

--- a/examples/pglite-multiple/package.json
+++ b/examples/pglite-multiple/package.json
@@ -8,11 +8,11 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
+    "@electric-sql/pglite": "0.2.0-alpha.8",
     "pg-gateway": "*"
   },
   "devDependencies": {
     "@biomejs/biome": "1.8.3",
-    "@electric-sql/pglite": "0.2.0-alpha.8",
     "@total-typescript/tsconfig": "^1.0.4",
     "@types/node": "^20.14.11",
     "tsx": "^4.16.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,11 +12,11 @@
     "examples/pglite-auth": {
       "name": "pglite-auth-example",
       "dependencies": {
+        "@electric-sql/pglite": "0.2.0-alpha.8",
         "pg-gateway": "*"
       },
       "devDependencies": {
         "@biomejs/biome": "1.8.3",
-        "@electric-sql/pglite": "0.2.0-alpha.8",
         "@total-typescript/tsconfig": "^1.0.4",
         "@types/node": "^20.14.11",
         "tsx": "^4.16.2",
@@ -26,11 +26,11 @@
     "examples/pglite-multiple": {
       "name": "pglite-multiple-example",
       "dependencies": {
+        "@electric-sql/pglite": "0.2.0-alpha.8",
         "pg-gateway": "*"
       },
       "devDependencies": {
         "@biomejs/biome": "1.8.3",
-        "@electric-sql/pglite": "0.2.0-alpha.8",
         "@total-typescript/tsconfig": "^1.0.4",
         "@types/node": "^20.14.11",
         "tsx": "^4.16.2",
@@ -209,7 +209,6 @@
       "version": "0.2.0-alpha.8",
       "resolved": "https://registry.npmjs.org/@electric-sql/pglite/-/pglite-0.2.0-alpha.8.tgz",
       "integrity": "sha512-+fQuj4k1J6YOM3HHuPHMJ+cdhIdXF6xXoo5q61tCTxqQ+cm30PIFE6uT0x/ePPSgNUjTyIYaFYAsdEo3er4uZw==",
-      "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -2908,7 +2907,6 @@
       "license": "MIT",
       "devDependencies": {
         "@biomejs/biome": "1.8.3",
-        "@electric-sql/pglite": "0.2.0-alpha.8",
         "@total-typescript/tsconfig": "^1.0.4",
         "@types/node": "^20.14.11",
         "pg": "^8.12.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
       },
       "devDependencies": {
         "@biomejs/biome": "1.8.3",
-        "@electric-sql/pglite": "0.2.0-alpha.7",
+        "@electric-sql/pglite": "0.2.0-alpha.8",
         "@total-typescript/tsconfig": "^1.0.4",
         "@types/node": "^20.14.11",
         "tsx": "^4.16.2",
@@ -30,7 +30,7 @@
       },
       "devDependencies": {
         "@biomejs/biome": "1.8.3",
-        "@electric-sql/pglite": "0.2.0-alpha.7",
+        "@electric-sql/pglite": "0.2.0-alpha.8",
         "@total-typescript/tsconfig": "^1.0.4",
         "@types/node": "^20.14.11",
         "tsx": "^4.16.2",
@@ -206,10 +206,11 @@
       }
     },
     "node_modules/@electric-sql/pglite": {
-      "version": "0.2.0-alpha.7",
-      "resolved": "https://registry.npmjs.org/@electric-sql/pglite/-/pglite-0.2.0-alpha.7.tgz",
-      "integrity": "sha512-XdP7pTzxCleaOacBPtXEX5QrrFfcSSsl3ULBcRF7Ohxu56nJsBSalMATLGAlu+NQKsgiHKRM62GG37TfiXc8HQ==",
-      "dev": true
+      "version": "0.2.0-alpha.8",
+      "resolved": "https://registry.npmjs.org/@electric-sql/pglite/-/pglite-0.2.0-alpha.8.tgz",
+      "integrity": "sha512-+fQuj4k1J6YOM3HHuPHMJ+cdhIdXF6xXoo5q61tCTxqQ+cm30PIFE6uT0x/ePPSgNUjTyIYaFYAsdEo3er4uZw==",
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.21.5",
@@ -2903,11 +2904,11 @@
       }
     },
     "packages/pg-gateway": {
-      "version": "0.3.0-alpha.1",
+      "version": "0.3.0-alpha.2",
       "license": "MIT",
       "devDependencies": {
         "@biomejs/biome": "1.8.3",
-        "@electric-sql/pglite": "0.2.0-alpha.7",
+        "@electric-sql/pglite": "0.2.0-alpha.8",
         "@total-typescript/tsconfig": "^1.0.4",
         "@types/node": "^20.14.11",
         "pg": "^8.12.0",

--- a/packages/pg-gateway/package.json
+++ b/packages/pg-gateway/package.json
@@ -26,7 +26,6 @@
   },
   "devDependencies": {
     "@biomejs/biome": "1.8.3",
-    "@electric-sql/pglite": "0.2.0-alpha.8",
     "@total-typescript/tsconfig": "^1.0.4",
     "@types/node": "^20.14.11",
     "pg": "^8.12.0",

--- a/packages/pg-gateway/package.json
+++ b/packages/pg-gateway/package.json
@@ -6,9 +6,7 @@
   "type": "module",
   "main": "dist/index.cjs",
   "types": "dist/index.d.ts",
-  "files": [
-    "dist/**/*"
-  ],
+  "files": ["dist/**/*"],
   "exports": {
     ".": {
       "import": "./dist/index.js",
@@ -28,7 +26,7 @@
   },
   "devDependencies": {
     "@biomejs/biome": "1.8.3",
-    "@electric-sql/pglite": "0.2.0-alpha.7",
+    "@electric-sql/pglite": "0.2.0-alpha.8",
     "@total-typescript/tsconfig": "^1.0.4",
     "@types/node": "^20.14.11",
     "pg": "^8.12.0",


### PR DESCRIPTION
PGlite `0.2.0-alpha.7` had a bug preventing pg-gateway to build correctly with TypeScript.
