### PR TITLE
fix: guard against ssl requirement

### DIFF
--- a/packages/pg-gateway/src/connection.ts
+++ b/packages/pg-gateway/src/connection.ts
@@ -231,6 +231,16 @@ export default class PostgresConnection {
         if (this.isSslRequest(message)) {
           await this.handleSslRequest();
         } else if (this.isStartupMessage(message)) {
+          // Guard against SSL connection not being established when `tls` is enabled
+          if (this.options.tls && !this.secureSocket) {
+            this.sendError({
+              severity: 'FATAL',
+              code: '08P01',
+              message: 'SSL connection is required',
+            });
+            this.socket.end();
+            return;
+          }
           // the next step is determined by handleStartupMessage
           this.handleStartupMessage(message);
         } else {


### PR DESCRIPTION
## What kind of change does this PR introduce?

fix

## What is the current behavior?

if ssl is required (implied by `options.tls` being set), we accept any messages even if the TLS connection isn't established.

## What is the new behavior?

We now prevent messages other than "SslRequest" if ssl is required and the secure connection isn't established.