### PR TITLE
fix: call onStartup option

### DIFF
--- a/examples/pglite-auth/cert.ts
+++ b/examples/pglite-auth/cert.ts
@@ -19,7 +19,6 @@ const server = net.createServer((socket) => {
     async onStartup() {
       // Wait for PGlite to be ready before further processing
       await db.waitReady;
-      return false;
     },
     async onMessage(data, { isAuthenticated }) {
       // Only forward messages to PGlite after authentication

--- a/examples/pglite-auth/md5.ts
+++ b/examples/pglite-auth/md5.ts
@@ -21,7 +21,6 @@ const server = net.createServer((socket) => {
     async onStartup() {
       // Wait for PGlite to be ready before further processing
       await db.waitReady;
-      return false;
     },
     async onMessage(data, { isAuthenticated }) {
       // Only forward messages to PGlite after authentication

--- a/examples/pglite-auth/password.ts
+++ b/examples/pglite-auth/password.ts
@@ -24,7 +24,6 @@ const server = net.createServer((socket) => {
     async onStartup() {
       // Wait for PGlite to be ready before further processing
       await db.waitReady;
-      return false;
     },
     async onMessage(data, { isAuthenticated }) {
       // Only forward messages to PGlite after authentication

--- a/examples/pglite-auth/scram-sha-256.ts
+++ b/examples/pglite-auth/scram-sha-256.ts
@@ -22,7 +22,6 @@ const server = net.createServer((socket) => {
     async onStartup() {
       // Wait for PGlite to be ready before further processing
       await db.waitReady;
-      return false;
     },
     async onMessage(data, { isAuthenticated }) {
       // Only forward messages to PGlite after authentication

--- a/examples/pglite-auth/trust.ts
+++ b/examples/pglite-auth/trust.ts
@@ -14,7 +14,6 @@ const server = net.createServer((socket) => {
     async onStartup() {
       // Wait for PGlite to be ready before further processing
       await db.waitReady;
-      return false;
     },
     async onMessage(data, { isAuthenticated }) {
       // Only forward messages to PGlite after authentication

--- a/examples/pglite-multiple/index.ts
+++ b/examples/pglite-multiple/index.ts
@@ -65,7 +65,6 @@ const server = net.createServer((socket) => {
     async onStartup() {
       // Wait for PGlite to be ready before further processing
       await db.waitReady;
-      return false;
     },
     async onMessage(data, { isAuthenticated }) {
       // Only forward messages to PGlite after authentication

--- a/packages/pg-gateway/src/connection.ts
+++ b/packages/pg-gateway/src/connection.ts
@@ -63,15 +63,8 @@ export type PostgresConnectionOptions = {
    * This is called after the connection is upgraded to TLS (if TLS is being used)
    * but before authentication messages are sent to the frontend.
    *
-   * Callback should return `true` to indicate that it has responded to the startup
-   * message and no further processing should occur. Return `false` to continue
-   * built-in processing.
-   *
-   * **Warning:** By managing the post-startup response yourself (returning `true`),
-   * you bypass further processing by the `PostgresConnection` which means some state
-   * may not be collected and hooks won't be called.
    */
-  onStartup?(state: ConnectionState): boolean | Promise<boolean>;
+  onStartup?(state: ConnectionState): void | Promise<void>;
 
   /**
    * Callback after a successful authentication has completed.
@@ -133,6 +126,7 @@ export default class PostgresConnection {
   secureSocket?: TLSSocket;
   hasStarted = false;
   isAuthenticated = false;
+  detached = false;
   writer = new BufferWriter();
   reader = new BufferReader();
   clientInfo?: ClientInfo;
@@ -192,6 +186,7 @@ export default class PostgresConnection {
    */
   detach() {
     this.removeSocketHandlers(this.socket);
+    this.detached = true;
     return this.socket;
   }
 
@@ -218,6 +213,11 @@ export default class PostgresConnection {
     this.socket.pause();
     const messageSkip = await this.options.onMessage?.(message, this.state);
     this.socket.resume();
+
+    // the socket was detached during onMessage, we skip further processing
+    if (this.detached) {
+      return;
+    }
 
     if (messageSkip) {
       if (this.isStartupMessage(message)) {
@@ -316,15 +316,13 @@ export default class PostgresConnection {
 
     this.hasStarted = true;
 
-    if (this.options.onStartup) {
-      this.socket.pause();
-      const skipFurtherProcessing = await this.options.onStartup(this.state);
-      this.socket.resume();
+    this.socket.pause();
+    await this.options.onStartup?.(this.state);
+    this.socket.resume();
 
-      if (skipFurtherProcessing) {
-        this.step = ServerStep.ReadyForQuery;
-        return;
-      }
+    // the socket was detached during onStartup, we skip further processing
+    if (this.detached) {
+      return;
     }
 
     if (this.options.auth.method === 'trust') {


### PR DESCRIPTION
We were not calling `onStartup` option, so users couldn't use the hook. 😅 

@gregnr Can you check if the skipping logic is accurate here?

I also move the call of `onAuthenticated` a bit to be better aligned with the whole flow.