### PR TITLE
feat: add callback form for serverVersion

### DIFF
--- a/packages/pg-gateway/src/connection.types.ts
+++ b/packages/pg-gateway/src/connection.types.ts
@@ -13,9 +13,18 @@ export type TlsInfo = {
   sniServerName?: string;
 };
 
+export const ServerStep = {
+  AwaitingInitialMessage: 'AwaitingInitialMessage',
+  PerformingAuthentication: 'PerformingAuthentication',
+  ReadyForQuery: 'ReadyForQuery',
+} as const;
+
+export type ServerStep = (typeof ServerStep)[keyof typeof ServerStep];
+
 export type ConnectionState = {
   hasStarted: boolean;
   isAuthenticated: boolean;
   clientInfo?: ClientInfo;
   tlsInfo?: TlsInfo;
+  step: ServerStep;
 };


### PR DESCRIPTION
Adding a way to provide the serverVersion by using a callback, for when users want to define serverVersion dynamically and/or depending on the connection state.

I also added the `step` state to the connection state.