### PR TITLE
`onMessage` API change: response data and iterators

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,24 +190,42 @@ const connection = new PostgresConnection(socket, {
 
 ### `onMessage()`
 
-This hook gives you access to raw messages at any point in the protocol lifecycle.
+This hook gives you access to raw messages at any point in the protocol lifecycle:
+
+```typescript
+const connection = new PostgresConnection(socket, {
+  async onMessage(data, state) {
+    // Observe or handle raw messages yourself
+  },
+});
+```
 
 1. The first argument contains the raw `Buffer` data in the message
 2. The second argument contains a [`state`](#state) object which holds connection information gathered so far and can be used to understand where the protocol is at in its lifecycle.
 
-The callback should return `true` to indicate that you have handled the message response yourself and that no further processing should be done. Returning `false` will result in further processing by the `PostgresConnection`. The callback can be either synchronous or asynchronous.
-
-> **Warning:** By managing the message yourself (returning `true`), you bypass further processing by the `PostgresConnection` which means some state may not be collected and hooks won't be called depending on where the protocol is at in its lifecycle.
+The callback can optionally return raw `Uint8Array` response data that will be sent back to the client:
 
 ```typescript
 const connection = new PostgresConnection(socket, {
-  async onMessage(data, { hasStarted, isAuthenticated }) {
-    // Handle raw messages yourself
-
-    return false;
+  async onMessage(data, state) {
+    return new Uint8Array(...);
   },
 });
 ```
+
+It can also return multiple `Uint8Array` responses via an `Iterable<Uint8Array>` or `AsyncIterable<Uint8Array>`. This means you can turn this hook into a generator function to asynchronously stream responses back to the client:
+
+```typescript
+const connection = new PostgresConnection(socket, {
+  async *onMessage(data, state) {
+    yield new Uint8Array(...);;
+    await new Promise((r) => setTimeout(r, 1000));
+    yield new Uint8Array(...);;
+  },
+});
+```
+
+> **Warning:** By managing the message yourself (returning data), you bypass further processing by the `PostgresConnection` which means some state may not be collected and hooks won't be called depending on where the protocol is at in its lifecycle. If you wish to hook into messages without bypassing further processing, do not return any data from this callback.
 
 See [PGlite](#pglite) for an example on how you might use this.
 
@@ -292,18 +310,11 @@ const server = net.createServer((socket) => {
     async onMessage(data, { isAuthenticated }) {
       // Only forward messages to PGlite after authentication
       if (!isAuthenticated) {
-        return false;
+        return;
       }
 
-      // Forward raw message to PGlite
-      try {
-        const [[_, responseData]] = await db.execProtocol(data);
-        connection.sendData(responseData);
-      } catch (err) {
-        connection.sendError(err);
-        connection.sendReadyForQuery();
-      }
-      return true;
+      // Forward raw message to PGlite and send response to client
+      return await db.execProtocolRaw(data);
     },
   });
 

--- a/examples/pglite-auth/cert.ts
+++ b/examples/pglite-auth/cert.ts
@@ -23,21 +23,11 @@ const server = net.createServer((socket) => {
     async onMessage(data, { isAuthenticated }) {
       // Only forward messages to PGlite after authentication
       if (!isAuthenticated) {
-        return false;
+        return;
       }
 
-      // Forward raw message to PGlite
-      try {
-        const [result] = await db.execProtocol(data);
-        if (result) {
-          const [_, responseData] = result;
-          connection.sendData(responseData);
-        }
-      } catch (err) {
-        connection.sendError(err as BackendError);
-        connection.sendReadyForQuery();
-      }
-      return true;
+      // Forward raw message to PGlite and send response to client
+      return await db.execProtocolRaw(data);
     },
   });
 

--- a/examples/pglite-auth/md5.ts
+++ b/examples/pglite-auth/md5.ts
@@ -25,21 +25,11 @@ const server = net.createServer((socket) => {
     async onMessage(data, { isAuthenticated }) {
       // Only forward messages to PGlite after authentication
       if (!isAuthenticated) {
-        return false;
+        return;
       }
 
-      // Forward raw message to PGlite
-      try {
-        const [result] = await db.execProtocol(data);
-        if (result) {
-          const [_, responseData] = result;
-          connection.sendData(responseData);
-        }
-      } catch (err) {
-        connection.sendError(err as BackendError);
-        connection.sendReadyForQuery();
-      }
-      return true;
+      // Forward raw message to PGlite and send response to client
+      return await db.execProtocolRaw(data);
     },
   });
 

--- a/examples/pglite-auth/password.ts
+++ b/examples/pglite-auth/password.ts
@@ -28,22 +28,11 @@ const server = net.createServer((socket) => {
     async onMessage(data, { isAuthenticated }) {
       // Only forward messages to PGlite after authentication
       if (!isAuthenticated) {
-        return false;
+        return;
       }
 
-      // Forward raw message to PGlite
-      // Forward raw message to PGlite
-      try {
-        const [result] = await db.execProtocol(data);
-        if (result) {
-          const [_, responseData] = result;
-          connection.sendData(responseData);
-        }
-      } catch (err) {
-        connection.sendError(err as BackendError);
-        connection.sendReadyForQuery();
-      }
-      return true;
+      // Forward raw message to PGlite and send response to client
+      return await db.execProtocolRaw(data);
     },
   });
 

--- a/examples/pglite-auth/scram-sha-256.ts
+++ b/examples/pglite-auth/scram-sha-256.ts
@@ -26,21 +26,11 @@ const server = net.createServer((socket) => {
     async onMessage(data, { isAuthenticated }) {
       // Only forward messages to PGlite after authentication
       if (!isAuthenticated) {
-        return false;
+        return;
       }
 
-      // Forward raw message to PGlite
-      try {
-        const [result] = await db.execProtocol(data);
-        if (result) {
-          const [_, responseData] = result;
-          connection.sendData(responseData);
-        }
-      } catch (err) {
-        connection.sendError(err as BackendError);
-        connection.sendReadyForQuery();
-      }
-      return true;
+      // Forward raw message to PGlite and send response to client
+      return await db.execProtocolRaw(data);
     },
   });
 

--- a/examples/pglite-auth/trust.ts
+++ b/examples/pglite-auth/trust.ts
@@ -18,21 +18,11 @@ const server = net.createServer((socket) => {
     async onMessage(data, { isAuthenticated }) {
       // Only forward messages to PGlite after authentication
       if (!isAuthenticated) {
-        return false;
+        return;
       }
 
-      // Forward raw message to PGlite
-      try {
-        const [result] = await db.execProtocol(data);
-        if (result) {
-          const [_, responseData] = result;
-          connection.sendData(responseData);
-        }
-      } catch (err) {
-        connection.sendError(err as BackendError);
-        connection.sendReadyForQuery();
-      }
-      return true;
+      // Forward raw message to PGlite and send response to client
+      return await db.execProtocolRaw(data);
     },
   });
 

--- a/examples/pglite-multiple/index.ts
+++ b/examples/pglite-multiple/index.ts
@@ -69,21 +69,11 @@ const server = net.createServer((socket) => {
     async onMessage(data, { isAuthenticated }) {
       // Only forward messages to PGlite after authentication
       if (!isAuthenticated) {
-        return false;
+        return;
       }
 
-      // Forward raw message to PGlite
-      try {
-        const [result] = await db.execProtocol(data);
-        if (result) {
-          const [_, responseData] = result;
-          connection.sendData(responseData);
-        }
-      } catch (err) {
-        connection.sendError(err as BackendError);
-        connection.sendReadyForQuery();
-      }
-      return true;
+      // Forward raw message to PGlite and send response to client
+      return await db.execProtocolRaw(data);
     },
   });
 


### PR DESCRIPTION
The point of the `onMessage` hook is to:
- Observe/log messages as they come through (passive)
- Manage the response yourself (active)

This PR changes the `onMessage` hook to allow you to return response data directly. It provides a cleaner & more intuitive API than the current return `true`/`false` approach.

## Current API

Currently if you wanted to respond to the message yourself you have to manually call the `connection.sendData()` method and return `true` to indicate that you are managing the response yourself and no further built-in processing should occur:

```typescript
const connection = new PostgresConnection(socket, {
  onMessage() {
    connection.sendData(new Uint8Array(...));
    return true;
  },
});
```

Or alternatively you can return `false` to indicate that you didn't send any response and built-in processing should continue.

## New API

The new API simply allows you to return the response data directly from the callback:

```typescript
const connection = new PostgresConnection(socket, {
  onMessage() {
    return new Uint8Array(...);
  },
});
```

Returning a `Uint8Array` will result in that data being automatically sent to the client. This indicates that you are managing the response yourself and the `PostgresConnection` will skip further built-in processing.

If you want built-in processing to continue, simply don't return anything.

With this change, our PGlite example changes from:

```typescript
const connection = new PostgresConnection(socket, {
  async onMessage(data, { isAuthenticated }) {
    // Only forward messages to PGlite after authentication
    if (!isAuthenticated) {
      return false;
    }

    // Forward raw message to PGlite and send response to client
    const responseData = await db.execProtocolRaw(data);
    connection.sendData(responseData);

    return true;
  },
});
```

to:

```typescript
const connection = new PostgresConnection(socket, {
  async onMessage(data, { isAuthenticated }) {
    // Only forward messages to PGlite after authentication
    if (!isAuthenticated) {
      return;
    }

    // Forward raw message to PGlite and send response to client
    return await db.execProtocolRaw(data);
  },
});
```

## Sending multiple responses
This PR also introduces [async iterators](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/AsyncIterator), the modern approach to streaming. Simply returning an `Iterable<Uint8Array>` or `AsyncIterable<Uint8Array>` from `onMessage()` will cause the `PostgresConnection` to iterate through each `Uint8Array` and send them to the client.

Importantly this means `onMessage()` can now be a generator function, yielding responses asynchronously:

```typescript
const connection = new PostgresConnection(socket, {
  async *onMessage(data, state) {
    yield new Uint8Array(...);;
    await new Promise((r) => setTimeout(r, 1000));
    yield new Uint8Array(...);;
  },
});
```

The above generator function will stream each `Uint8Array` response asynchronously back to the client. This means the client receives each response immediately vs. waiting for the entire hook to complete first.

## Future
This is the first step to introducing async iterators to this lib, with plans to make them first class throughout (WIP). For example, they will be used in the `onQuery()` hook when streaming rows asynchronously back to the client (WIP).