### PR TITLE
feat: end method

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,17 @@
+{
+  "[javascript]": {
+    "editor.defaultFormatter": "biomejs.biome"
+  },
+  "[json]": {
+    "editor.defaultFormatter": "biomejs.biome"
+  },
+  "[jsonc]": {
+    "editor.defaultFormatter": "biomejs.biome"
+  },
+  "[typescript]": {
+    "editor.defaultFormatter": "biomejs.biome"
+  },
+  "[typescriptreact]": {
+    "editor.defaultFormatter": "biomejs.biome"
+  }
+}

--- a/packages/pg-gateway/src/connection.ts
+++ b/packages/pg-gateway/src/connection.ts
@@ -117,10 +117,8 @@ export type PostgresConnectionOptions = {
 };
 
 export type MessageResponse =
-  | undefined
-  | Uint8Array
-  | Iterable<Uint8Array>
-  | AsyncIterable<Uint8Array>;
+  // biome-ignore lint/suspicious/noConfusingVoidType: this is a return type
+  void | Uint8Array | Iterable<Uint8Array> | AsyncIterable<Uint8Array>;
 
 export default class PostgresConnection {
   private step: ServerStep = ServerStep.AwaitingInitialMessage;
@@ -194,6 +192,15 @@ export default class PostgresConnection {
     this.removeSocketHandlers(this.socket);
     this.detached = true;
     return this.socket;
+  }
+
+  /**
+   * Ends the `PostgresConnection`.
+   * The socket will be closed and no more handlers will be called.
+   */
+  end() {
+    this.removeSocketHandlers(this.socket);
+    this.socket.end();
   }
 
   /**


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR introduces a new `end` method to `PostgresConnection`, allowing us to have more control over socket termination.

## What is the current behavior?

Currently if we end the socket manually in some of the `onX` options, for example `onTlsUpgrade`, we end up receiving new messages while the socket is already closed, which causes errors like `ERR_STREAM_WRITE_AFTER_END`.

## What is the new behavior?

The user can now call `connection.end()` which will gracefully handle the socket by removing all the internal listeners before ending the socket. It means that we won't process any further messages.

## Additional context

As a user I could also call `connection.detach()` before ending the socket, but it's not super intuitive. `PostgresConnection` should be seen as a smart `net.Socket`, aware of the Postgres wire protocol, so it makes sense to me to expose this `end` method.