### PR TITLE
Add test for PGlite hanging after error message

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -8,8 +8,7 @@
       "jsr:@std/testing": "jsr:@std/testing@1.0.1",
       "npm:@biomejs/biome@1.8.3": "npm:@biomejs/biome@1.8.3",
       "npm:@biomejs/biome@^1.8.3": "npm:@biomejs/biome@1.8.3",
-      "npm:@electric-sql/pglite": "npm:@electric-sql/pglite@0.2.6",
-      "npm:@electric-sql/pglite@^0.2.6": "npm:@electric-sql/pglite@0.2.6",
+      "npm:@electric-sql/pglite@^0.2.7": "npm:@electric-sql/pglite@0.2.7",
       "npm:@jsr/std__bytes@^1.0.2": "npm:@jsr/std__bytes@1.0.2",
       "npm:@jsr/std__crypto@^1.0.3": "npm:@jsr/std__crypto@1.0.3",
       "npm:@jsr/std__encoding@^1.0.3": "npm:@jsr/std__encoding@1.0.3",
@@ -153,8 +152,8 @@
           "tough-cookie": "tough-cookie@4.1.4"
         }
       },
-      "@electric-sql/pglite@0.2.6": {
-        "integrity": "sha512-tyWWxj1Z1Pd4BqBZL1ER2SXaCn5s9N0bxTQCAkGaaWe8r9EEe1bNs20RAG3/+ZeBJtDrk8y5xjocactL+4aIXg==",
+      "@electric-sql/pglite@0.2.7": {
+        "integrity": "sha512-8Il//XHTAtZ8VeQF+6P1UjsIoaAJyO4LwOMoXhSFaHpmkwKs63cUhHHNzLzUmcZvP/ZTmlT3+xTiWfU/EyoxwQ==",
         "dependencies": {}
       },
       "@esbuild/aix-ppc64@0.21.5": {
@@ -2056,7 +2055,7 @@
         "packageJson": {
           "dependencies": [
             "npm:@biomejs/biome@1.8.3",
-            "npm:@electric-sql/pglite@^0.2.6",
+            "npm:@electric-sql/pglite@^0.2.7",
             "npm:@total-typescript/tsconfig@^1.0.4",
             "npm:@types/node@^20.14.11",
             "npm:pg-gateway",
@@ -2069,7 +2068,7 @@
         "packageJson": {
           "dependencies": [
             "npm:@biomejs/biome@1.8.3",
-            "npm:@electric-sql/pglite@^0.2.6",
+            "npm:@electric-sql/pglite@^0.2.7",
             "npm:@total-typescript/tsconfig@^1.0.4",
             "npm:@types/node@^20.14.11",
             "npm:pg-gateway",
@@ -2094,7 +2093,7 @@
         "packageJson": {
           "dependencies": [
             "npm:@biomejs/biome@^1.8.3",
-            "npm:@electric-sql/pglite@^0.2.6",
+            "npm:@electric-sql/pglite@^0.2.7",
             "npm:@jsr/std__bytes@^1.0.2",
             "npm:@jsr/std__crypto@^1.0.3",
             "npm:@jsr/std__encoding@^1.0.3",

--- a/examples/pglite-auth/package.json
+++ b/examples/pglite-auth/package.json
@@ -7,7 +7,7 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
-    "@electric-sql/pglite": "^0.2.6",
+    "@electric-sql/pglite": "^0.2.7",
     "pg-gateway": "*"
   },
   "devDependencies": {

--- a/examples/pglite-multiple/package.json
+++ b/examples/pglite-multiple/package.json
@@ -8,7 +8,7 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
-    "@electric-sql/pglite": "^0.2.6",
+    "@electric-sql/pglite": "^0.2.7",
     "pg-gateway": "*"
   },
   "devDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
     "examples/pglite-auth": {
       "name": "pglite-auth-example",
       "dependencies": {
-        "@electric-sql/pglite": "^0.2.6",
+        "@electric-sql/pglite": "^0.2.7",
         "pg-gateway": "*"
       },
       "devDependencies": {
@@ -26,7 +26,7 @@
     "examples/pglite-multiple": {
       "name": "pglite-multiple-example",
       "dependencies": {
-        "@electric-sql/pglite": "^0.2.6",
+        "@electric-sql/pglite": "^0.2.7",
         "pg-gateway": "*"
       },
       "devDependencies": {

--- a/packages/pg-gateway/test/deno/tcp.test.ts
+++ b/packages/pg-gateway/test/deno/tcp.test.ts
@@ -3,7 +3,7 @@ import pg from 'npm:pg';
 
 import { expect } from 'jsr:@std/expect';
 import { afterAll, beforeAll, describe, it } from 'jsr:@std/testing/bdd';
-import { PGlite } from 'npm:@electric-sql/pglite';
+import { PGlite } from 'npm:@electric-sql/pglite@^0.2.7';
 import { fromDenoConn } from 'pg-gateway/deno';
 
 const { Client } = pg;

--- a/packages/pg-gateway/test/node/pg.test.ts
+++ b/packages/pg-gateway/test/node/pg.test.ts
@@ -47,4 +47,15 @@ describe('pg client with pglite', () => {
     const [{ message }] = res.rows;
     expect(message).toBe('Hello world!');
   });
+
+  it('invalid sql throws an error but does not hang', async () => {
+    await using client = await connect();
+    const promise = client.query('invalid sql');
+    await expect(promise).rejects.toThrowError('syntax error at or near "invalid"');
+
+    // Run another query to see if the connection hung
+    const res = await client.query("select 'Hello world!' as message");
+    const [{ message }] = res.rows;
+    expect(message).toBe('Hello world!');
+  });
 });


### PR DESCRIPTION
Adds test for PGlite hanging after sending an error message (ie. never follows up with a `ReadyForQuery`). Was discovered in 0.2.6, fixed in 0.2.7.