### PR TITLE
Bundle `@std` deps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1345,19 +1345,22 @@
       "name": "@jsr/std__bytes",
       "version": "1.0.2",
       "resolved": "https://npm.jsr.io/~/11/@jsr/std__bytes/1.0.2.tgz",
-      "integrity": "sha512-bkZ1rllRB1qsxFbPqtO1VAYTW2+3ZDmf6pcy8xihKS33r0Z1ly6/E/5DoapnJsNy05LdnANUySWt5kj/awgGdg=="
+      "integrity": "sha512-bkZ1rllRB1qsxFbPqtO1VAYTW2+3ZDmf6pcy8xihKS33r0Z1ly6/E/5DoapnJsNy05LdnANUySWt5kj/awgGdg==",
+      "dev": true
     },
     "node_modules/@std/crypto": {
       "name": "@jsr/std__crypto",
       "version": "1.0.3",
       "resolved": "https://npm.jsr.io/~/11/@jsr/std__crypto/1.0.3.tgz",
-      "integrity": "sha512-B/4PCckQfbfVMyQvG2I15QbN4vfx1S0tXKstpSlzuSmVwGmAOT/DLCtrbrAKlMiJBN4Zb53KaAJQm8VgkZ+bDg=="
+      "integrity": "sha512-B/4PCckQfbfVMyQvG2I15QbN4vfx1S0tXKstpSlzuSmVwGmAOT/DLCtrbrAKlMiJBN4Zb53KaAJQm8VgkZ+bDg==",
+      "dev": true
     },
     "node_modules/@std/encoding": {
       "name": "@jsr/std__encoding",
       "version": "1.0.3",
       "resolved": "https://npm.jsr.io/~/11/@jsr/std__encoding/1.0.3.tgz",
-      "integrity": "sha512-l4R27qOsop6yYub8zpMj4tT6OCW3AqD14XswRrOs9DiD9DHWG95lxPNAek3+W4flBqIg7ExQy25VKu+qHqSV0g=="
+      "integrity": "sha512-l4R27qOsop6yYub8zpMj4tT6OCW3AqD14XswRrOs9DiD9DHWG95lxPNAek3+W4flBqIg7ExQy25VKu+qHqSV0g==",
+      "dev": true
     },
     "node_modules/@testing-library/dom": {
       "version": "10.4.0",
@@ -4987,16 +4990,14 @@
     "packages/pg-gateway": {
       "version": "0.3.0-beta.1",
       "license": "MIT",
-      "dependencies": {
-        "@std/bytes": "npm:@jsr/std__bytes@^1.0.2",
-        "@std/crypto": "npm:@jsr/std__crypto@^1.0.3",
-        "@std/encoding": "npm:@jsr/std__encoding@^1.0.3"
-      },
       "devDependencies": {
         "@biomejs/biome": "^1.8.3",
         "@electric-sql/pglite": "^0.2.6",
         "@nodeweb/knex": "^3.1.0-alpha.13",
         "@nodeweb/pg": "^8.12.0-alpha.5",
+        "@std/bytes": "npm:@jsr/std__bytes@^1.0.2",
+        "@std/crypto": "npm:@jsr/std__crypto@^1.0.3",
+        "@std/encoding": "npm:@jsr/std__encoding@^1.0.3",
         "@total-typescript/tsconfig": "^1.0.4",
         "@types/node": "^20.14.11",
         "@types/pg": "^8.11.8",

--- a/packages/pg-gateway/package.json
+++ b/packages/pg-gateway/package.json
@@ -40,16 +40,14 @@
     "lint": "biome lint --error-on-warnings .",
     "type-check": "tsc --noEmit"
   },
-  "dependencies": {
-    "@std/bytes": "npm:@jsr/std__bytes@^1.0.2",
-    "@std/crypto": "npm:@jsr/std__crypto@^1.0.3",
-    "@std/encoding": "npm:@jsr/std__encoding@^1.0.3"
-  },
   "devDependencies": {
     "@biomejs/biome": "^1.8.3",
     "@electric-sql/pglite": "^0.2.6",
     "@nodeweb/knex": "^3.1.0-alpha.13",
     "@nodeweb/pg": "^8.12.0-alpha.5",
+    "@std/bytes": "npm:@jsr/std__bytes@^1.0.2",
+    "@std/crypto": "npm:@jsr/std__crypto@^1.0.3",
+    "@std/encoding": "npm:@jsr/std__encoding@^1.0.3",
     "@total-typescript/tsconfig": "^1.0.4",
     "@types/node": "^20.14.11",
     "@types/pg": "^8.11.8",


### PR DESCRIPTION
## Problem
We depend on 3 deps:
```
"@std/bytes": "npm:@jsr/std__bytes@^1.0.2",
"@std/crypto": "npm:@jsr/std__crypto@^1.0.3",
"@std/encoding": "npm:@jsr/std__encoding@^1.0.3"
```

which are hosted on JSR only (they are a part of Deno's standard lib). To make this work, JSR adds this to your `.npmrc`:
```
@jsr:registry=https://npm.jsr.io
```

So that JSR deps resolve through their own NPM-compat registry. This works great, unless you are publishing your own library. Published NPM packages don't include `.npmrc` (intentionally) so these deps aren't available to downstream users.

## Solution
Bundle them. We already use `tsup/esbuild` for internal bundling. To get these external deps to bundle, we just move them to dev dependencies and `tsup` will pick them up.