### PR TITLE
Docs: fix missing async in `createServer` callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ import { once } from 'node:events';
 import { fromNodeSocket } from 'pg-gateway/node';
 
 // Create a TCP server and listen for connections
-const server = createServer((socket) => {
+const server = createServer(async (socket) => {
   // Returns a `PostgresConnection` which manages the protocol lifecycle
   const connection = await fromNodeSocket(socket);
 });
@@ -458,10 +458,10 @@ With `pg-gateway`, we can serve PGlite over TCP by handling the startup/auth our
 
 ```typescript
 import { PGlite } from '@electric-sql/pglite';
-import net from 'node:net';
+import { createServer } from 'node:net';
 import { fromNodeSocket } from 'pg-gateway/node';
 
-const server = net.createServer((socket) => {
+const server = createServer(async (socket) => {
   // Each connection gets a fresh PGlite database,
   // since PGlite runs in single-user mode
   // (alternatively you could queue connections)
@@ -548,7 +548,7 @@ async function getServerById(id: string) {
   };
 }
 
-const server = createServer((socket) => {
+const server = createServer(async (socket) => {
   const connection = await fromNodeSocket(socket, {
     tls,
     // This hook occurs before startup messages are received from the client,

--- a/README.md
+++ b/README.md
@@ -669,12 +669,6 @@ _/etc/hosts_
 
 On Windows this file lives at `C:\Windows\System32\Drivers\etc\hosts`.
 
-## Development
-
-```shell
-npm run dev
-```
-
 ## License
 
 MIT

--- a/README.md
+++ b/README.md
@@ -508,7 +508,7 @@ You can test the connection using `psql`:
 psql -h localhost -U postgres
 ```
 
-You should be prompted for a password (`postgres`) and then brought into the `psql` REPL. At this point you are communicating directly with PGlite.
+You should immediately be brought into the `psql` REPL. At this point you are communicating directly with PGlite.
 
 ### Reverse Proxy using SNI
 

--- a/examples/pglite-auth/cert.ts
+++ b/examples/pglite-auth/cert.ts
@@ -1,16 +1,16 @@
 import { PGlite } from '@electric-sql/pglite';
-import fs from 'node:fs';
-import net from 'node:net';
+import { readFile } from 'node:fs/promises';
+import { createServer } from 'node:net';
 import { fromNodeSocket } from 'pg-gateway/node';
 
 const db = new PGlite();
 
-const server = net.createServer(async (socket) => {
+const server = createServer(async (socket) => {
   const connection = await fromNodeSocket(socket, {
     serverVersion: '16.3 (PGlite 0.2.0)',
     tls: {
-      key: fs.readFileSync('key.pem'),
-      cert: fs.readFileSync('cert.pem'),
+      key: await readFile('key.pem'),
+      cert: await readFile('cert.pem'),
     },
     auth: {
       method: 'cert',

--- a/examples/pglite-auth/md5.ts
+++ b/examples/pglite-auth/md5.ts
@@ -1,11 +1,11 @@
 import { PGlite } from '@electric-sql/pglite';
-import net from 'node:net';
+import { createServer } from 'node:net';
 import { createPreHashedPassword } from 'pg-gateway';
 import { fromNodeSocket } from 'pg-gateway/node';
 
 const db = new PGlite();
 
-const server = net.createServer(async (socket) => {
+const server = createServer(async (socket) => {
   const connection = await fromNodeSocket(socket, {
     serverVersion: '16.3 (PGlite 0.2.0)',
     auth: {

--- a/examples/pglite-auth/password.ts
+++ b/examples/pglite-auth/password.ts
@@ -1,10 +1,10 @@
 import { PGlite } from '@electric-sql/pglite';
-import net from 'node:net';
+import { createServer } from 'node:net';
 import { fromNodeSocket } from 'pg-gateway/node';
 
 const db = new PGlite();
 
-const server = net.createServer(async (socket) => {
+const server = createServer(async (socket) => {
   const connection = await fromNodeSocket(socket, {
     serverVersion: '16.3 (PGlite 0.2.0)',
     auth: {

--- a/examples/pglite-auth/scram-sha-256.ts
+++ b/examples/pglite-auth/scram-sha-256.ts
@@ -1,11 +1,11 @@
 import { PGlite } from '@electric-sql/pglite';
-import net from 'node:net';
+import { createServer } from 'node:net';
 import { createScramSha256Data } from 'pg-gateway';
 import { fromNodeSocket } from 'pg-gateway/node';
 
 const db = new PGlite();
 
-const server = net.createServer(async (socket) => {
+const server = createServer(async (socket) => {
   const connection = await fromNodeSocket(socket, {
     serverVersion: '16.3 (PGlite 0.2.0)',
     auth: {

--- a/examples/pglite-auth/trust.ts
+++ b/examples/pglite-auth/trust.ts
@@ -1,10 +1,10 @@
 import { PGlite } from '@electric-sql/pglite';
-import net from 'node:net';
+import { createServer } from 'node:net';
 import { fromNodeSocket } from 'pg-gateway/node';
 
 const db = new PGlite();
 
-const server = net.createServer(async (socket) => {
+const server = createServer(async (socket) => {
   const connection = await fromNodeSocket(socket, {
     serverVersion: '16.3 (PGlite 0.2.0)',
     auth: {

--- a/examples/pglite-multiple/index.ts
+++ b/examples/pglite-multiple/index.ts
@@ -1,6 +1,6 @@
 import { PGlite, type PGliteInterface } from '@electric-sql/pglite';
 import { mkdir, readFile } from 'node:fs/promises';
-import net from 'node:net';
+import { createServer } from 'node:net';
 import { type TlsOptionsCallback, createPreHashedPassword } from 'pg-gateway';
 import { fromNodeSocket } from 'pg-gateway/node';
 
@@ -21,7 +21,7 @@ function getIdFromServerName(serverName: string) {
   return id;
 }
 
-const server = net.createServer(async (socket) => {
+const server = createServer(async (socket) => {
   let db: PGliteInterface;
 
   const connection = await fromNodeSocket(socket, {


### PR DESCRIPTION
Our Node.js `createServer` callback needs to be async now that `fromNodeSocket()` is async. This fixes the docs to add this.

HT @BracketJohn 🫡 