### PR TITLE
Fix tsup CJS transpile errors

### DIFF
--- a/packages/pg-gateway/src/auth/cert.ts
+++ b/packages/pg-gateway/src/auth/cert.ts
@@ -21,7 +21,7 @@ export class CertAuthFlow extends BaseAuthFlow {
     validateCredentials: NonNullable<CertAuthOptions['validateCredentials']>;
   };
   private username: string;
-  private completed = false;
+  private completed: boolean;
 
   constructor(params: {
     auth: CertAuthOptions;
@@ -32,6 +32,7 @@ export class CertAuthFlow extends BaseAuthFlow {
   }) {
     super(params);
 
+    this.completed = false;
     this.auth = {
       ...params.auth,
       validateCredentials:

--- a/packages/pg-gateway/src/auth/md5.ts
+++ b/packages/pg-gateway/src/auth/md5.ts
@@ -32,7 +32,7 @@ export class Md5AuthFlow extends BaseAuthFlow {
   };
   private username: string;
   private salt: Uint8Array;
-  private completed = false;
+  private completed: boolean;
 
   constructor(params: {
     auth: Md5AuthOptions;
@@ -42,6 +42,8 @@ export class Md5AuthFlow extends BaseAuthFlow {
     connectionState: ConnectionState;
   }) {
     super(params);
+
+    this.completed = false;
     this.auth = {
       ...params.auth,
       validateCredentials:

--- a/packages/pg-gateway/src/auth/password.ts
+++ b/packages/pg-gateway/src/auth/password.ts
@@ -31,7 +31,7 @@ export class PasswordAuthFlow extends BaseAuthFlow {
     validateCredentials: NonNullable<PasswordAuthOptions['validateCredentials']>;
   };
   private username: string;
-  private completed = false;
+  private completed: boolean;
 
   constructor(params: {
     auth: PasswordAuthOptions;
@@ -41,6 +41,8 @@ export class PasswordAuthFlow extends BaseAuthFlow {
     connectionState: ConnectionState;
   }) {
     super(params);
+
+    this.completed = false;
     this.auth = {
       ...params.auth,
       validateCredentials:

--- a/packages/pg-gateway/src/auth/sasl/scram-sha-256.ts
+++ b/packages/pg-gateway/src/auth/sasl/scram-sha-256.ts
@@ -102,7 +102,7 @@ export class ScramSha256AuthFlow extends SaslMechanism implements AuthFlow {
   clientFirstMessageBare?: string;
   serverFirstMessage?: string;
   serverNonce?: string;
-  step: ScramSha256Step = ScramSha256Step.Initial;
+  step: ScramSha256Step;
   reader: BufferReader;
   scramSha256Data?: ScramSha256Data;
   connectionState: ConnectionState;
@@ -115,6 +115,8 @@ export class ScramSha256AuthFlow extends SaslMechanism implements AuthFlow {
     connectionState: ConnectionState;
   }) {
     super({ writer: params.writer });
+
+    this.step = ScramSha256Step.Initial;
     this.username = params.username;
     this.auth = {
       ...params.auth,


### PR DESCRIPTION
`tsup` has a [bug](https://github.com/egoist/tsup/issues/1124) that produces invalid CJS code under very specific conditions. Unfortunately we fall under these conditions and our CJS output contains the same error:
```
SyntaxError: Unexpected token ','
```

 One of these conditions is instantiating a class property outside of the constructor. This PR moves these instantiations to inside the constructor, which is logically equivalent but just less ergonomic. The CJS output is confirmed to be fixed after this change. We can move these back after the above `tsup` issue is resolved.

Fixes #23